### PR TITLE
Feat/aks and network modules

### DIFF
--- a/modules/aks/main.tf
+++ b/modules/aks/main.tf
@@ -1,0 +1,62 @@
+resource "azurerm_kubernetes_cluster" "this" {
+  name                = var.cluster_name
+  dns_prefix          = var.dns_prefix
+  location            = var.location
+  resource_group_name = var.resource_group_name
+
+  kubernetes_version        = var.kubernetes_version
+  automatic_upgrade_channel = var.upgrade_channel
+  sku_tier                  = var.sku_tier
+  oidc_issuer_enabled       = var.oidc_issuer_enabled
+  workload_identity_enabled = var.workload_identity_enabled
+
+  service_mesh_profile {
+    mode                             = var.service_mesh_mode
+    revisions                        = var.service_mesh_revisions
+    internal_ingress_gateway_enabled = var.service_mesh_internal_ingress_enabled
+  }
+
+  network_profile {
+    network_plugin      = var.network_plugin
+    network_policy      = var.network_policy
+    network_plugin_mode = var.network_plugin_mode
+
+    load_balancer_profile {
+      managed_outbound_ip_count = var.managed_outbound_ip_count
+      idle_timeout_in_minutes   = var.idle_timeout_in_minutes
+    }
+  }
+
+  default_node_pool {
+    name                        = var.node_pool_name
+    temporary_name_for_rotation = var.node_pool_temp_name
+    vm_size                     = var.node_pool_vm_size
+    vnet_subnet_id              = var.subnet_id
+    os_disk_size_gb             = var.os_disk_size_gb
+
+    node_count           = var.node_count
+
+    upgrade_settings {
+      drain_timeout_in_minutes      = var.node_pool_drain_timeout
+      max_surge                     = var.node_pool_max_surge
+      node_soak_duration_in_minutes = var.node_pool_soak_duration
+    }
+  }
+
+  auto_scaler_profile {
+    scale_down_delay_after_add = var.scale_down_delay
+    scan_interval              = var.scan_interval
+  }
+
+  api_server_access_profile {
+    authorized_ip_ranges = var.api_server_authorized_ip_ranges
+  }
+
+  key_vault_secrets_provider {
+    secret_rotation_enabled = var.secret_rotation_enabled
+  }
+
+  identity {
+    type = var.identity_type
+  }
+}

--- a/modules/aks/main.tf
+++ b/modules/aks/main.tf
@@ -17,9 +17,9 @@ resource "azurerm_kubernetes_cluster" "this" {
   }
 
   network_profile {
-  network_plugin      = "azure"
-  network_policy      = "azure"
-  network_plugin_mode = "overlay"
+    network_plugin      = "azure"
+    network_policy      = "azure"
+    network_plugin_mode = "overlay"
 
     load_balancer_profile {
       managed_outbound_ip_count = 2
@@ -34,7 +34,7 @@ resource "azurerm_kubernetes_cluster" "this" {
     vnet_subnet_id              = var.subnet_id
     os_disk_size_gb             = var.os_disk_size_gb
 
-    node_count           = var.node_count
+    node_count = var.node_count
 
     upgrade_settings {
       drain_timeout_in_minutes      = 5

--- a/modules/aks/outputs.tf
+++ b/modules/aks/outputs.tf
@@ -1,0 +1,21 @@
+output "cluster_name" {
+  description = "The name of the AKS cluster."
+  value       = azurerm_kubernetes_cluster.this.name
+}
+
+output "cluster_id" {
+  description = "The ID of the AKS cluster."
+  value       = azurerm_kubernetes_cluster.this.id
+}
+
+output "kube_admin_config" {
+  description = "Raw kubeconfig for the cluster admin."
+  value       = azurerm_kubernetes_cluster.this.kube_admin_config_raw
+  sensitive   = true
+}
+
+output "kube_config" {
+  description = "Raw kubeconfig for regular users."
+  value       = azurerm_kubernetes_cluster.this.kube_config_raw
+  sensitive   = true
+}

--- a/modules/aks/providers.tf
+++ b/modules/aks/providers.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.7.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "=4.33.0"
+    }
+  }
+}

--- a/modules/aks/variables.tf
+++ b/modules/aks/variables.tf
@@ -1,0 +1,167 @@
+variable "cluster_name" {
+  description = "The name of the AKS cluster."
+  type        = string
+}
+
+variable "dns_prefix" {
+  description = "The DNS prefix for the AKS cluster FQDN."
+  type        = string
+}
+
+variable "location" {
+  description = "Azure region where AKS cluster will be deployed."
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "Name of the resource group in which to create the AKS cluster."
+  type        = string
+}
+
+variable "kubernetes_version" {
+  description = "Kubernetes version for the AKS cluster."
+  type        = string
+}
+
+variable "upgrade_channel" {
+  description = "Automatic upgrade channel for AKS cluster."
+  type        = string
+  validation {
+    condition     = contains(["none", "patch", "rapid", "stable"], var.upgrade_channel)
+    error_message = "upgrade_channel must be one of: none, patch, rapid, stable."
+  }
+}
+
+variable "sku_tier" {
+  description = "The SKU tier for AKS (e.g., Free, Standard)."
+  type        = string
+}
+
+variable "oidc_issuer_enabled" {
+  description = "Enable OIDC issuer for AKS cluster."
+  type        = bool
+  default     = true
+}
+
+variable "workload_identity_enabled" {
+  description = "Enable workload identity for AKS cluster."
+  type        = bool
+  default     = true
+}
+
+variable "service_mesh_mode" {
+  description = "Service mesh mode, e.g., Istio."
+  type        = string
+}
+
+variable "service_mesh_revisions" {
+  description = "List of Istio control plane revisions to use."
+  type        = list(string)
+}
+
+variable "service_mesh_internal_ingress_enabled" {
+  description = "Whether to enable the internal Istio ingress gateway."
+  type        = bool
+}
+
+variable "network_plugin" {
+  description = "Network plugin for AKS (azure or kubenet)."
+  type        = string
+}
+
+variable "network_policy" {
+  description = "Network policy for AKS (azure or calico)."
+  type        = string
+}
+
+variable "network_plugin_mode" {
+  description = "Network plugin mode, e.g., overlay."
+  type        = string
+}
+
+variable "managed_outbound_ip_count" {
+  description = "Number of managed outbound IPs for the load balancer."
+  type        = number
+  default     = 1
+}
+
+variable "idle_timeout_in_minutes" {
+  description = "Idle timeout for load balancer outbound connections."
+  type        = number
+  default     = 15
+}
+
+variable "node_pool_name" {
+  description = "Name of the default node pool."
+  type        = string
+  default     = "default"
+}
+
+variable "node_pool_temp_name" {
+  description = "Temporary name for node pool during rotation."
+  type        = string
+}
+
+variable "node_pool_vm_size" {
+  description = "VM size for the default node pool."
+  type        = string
+}
+
+variable "subnet_id" {
+  description = "ID of the subnet for the AKS node pool."
+  type        = string
+}
+
+variable "os_disk_size_gb" {
+  description = "OS disk size in GB for node pool VMs."
+  type        = number
+  default     = 128
+}
+
+variable "node_count" {
+  description = "Number of nodes in the default node pool."
+  type        = number
+}
+
+variable "node_pool_drain_timeout" {
+  description = "Drain timeout in minutes during node upgrade."
+  type        = number
+  default     = 5
+}
+
+variable "node_pool_max_surge" {
+  description = "Maximum surge for node upgrades (e.g., 33%)."
+  type        = string
+}
+
+variable "node_pool_soak_duration" {
+  description = "Node soak duration in minutes before upgrade."
+  type        = number
+  default     = 0
+}
+
+variable "scale_down_delay" {
+  description = "Delay after scale up before scale down."
+  type        = string
+}
+
+variable "scan_interval" {
+  description = "Interval for auto-scaler scan."
+  type        = string
+}
+
+variable "api_server_authorized_ip_ranges" {
+  description = "Authorized IP ranges for API server access."
+  type        = list(string)
+}
+
+variable "secret_rotation_enabled" {
+  description = "Enable secret rotation for Key Vault provider."
+  type        = bool
+  default     = false
+}
+
+variable "identity_type" {
+  description = "Type of identity for AKS (SystemAssigned, UserAssigned)."
+  type        = string
+}

--- a/modules/aks/variables.tf
+++ b/modules/aks/variables.tf
@@ -3,11 +3,6 @@ variable "cluster_name" {
   type        = string
 }
 
-variable "dns_prefix" {
-  description = "The DNS prefix for the AKS cluster FQDN."
-  type        = string
-}
-
 variable "location" {
   description = "Azure region where AKS cluster will be deployed."
   type        = string
@@ -18,77 +13,19 @@ variable "resource_group_name" {
   type        = string
 }
 
+variable "subnet_id" {
+  description = "ID of the subnet for the AKS node pool."
+  type        = string
+}
+
 variable "kubernetes_version" {
   description = "Kubernetes version for the AKS cluster."
   type        = string
 }
 
-variable "upgrade_channel" {
-  description = "Automatic upgrade channel for AKS cluster."
-  type        = string
-  validation {
-    condition     = contains(["none", "patch", "rapid", "stable"], var.upgrade_channel)
-    error_message = "upgrade_channel must be one of: none, patch, rapid, stable."
-  }
-}
-
-variable "sku_tier" {
-  description = "The SKU tier for AKS (e.g., Free, Standard)."
-  type        = string
-}
-
-variable "oidc_issuer_enabled" {
-  description = "Enable OIDC issuer for AKS cluster."
-  type        = bool
-  default     = true
-}
-
-variable "workload_identity_enabled" {
-  description = "Enable workload identity for AKS cluster."
-  type        = bool
-  default     = true
-}
-
-variable "service_mesh_mode" {
-  description = "Service mesh mode, e.g., Istio."
-  type        = string
-}
-
-variable "service_mesh_revisions" {
-  description = "List of Istio control plane revisions to use."
-  type        = list(string)
-}
-
 variable "service_mesh_internal_ingress_enabled" {
   description = "Whether to enable the internal Istio ingress gateway."
   type        = bool
-}
-
-variable "network_plugin" {
-  description = "Network plugin for AKS (azure or kubenet)."
-  type        = string
-}
-
-variable "network_policy" {
-  description = "Network policy for AKS (azure or calico)."
-  type        = string
-}
-
-variable "network_plugin_mode" {
-  description = "Network plugin mode, e.g., overlay."
-  type        = string
-}
-
-variable "managed_outbound_ip_count" {
-  description = "Number of managed outbound IPs for the load balancer."
-  type        = number
-  default     = 1
-}
-
-variable "idle_timeout_in_minutes" {
-  description = "Idle timeout for load balancer outbound connections."
-  type        = number
-  default     = 15
 }
 
 variable "node_pool_name" {
@@ -97,20 +34,11 @@ variable "node_pool_name" {
   default     = "default"
 }
 
-variable "node_pool_temp_name" {
-  description = "Temporary name for node pool during rotation."
-  type        = string
-}
-
 variable "node_pool_vm_size" {
   description = "VM size for the default node pool."
   type        = string
 }
 
-variable "subnet_id" {
-  description = "ID of the subnet for the AKS node pool."
-  type        = string
-}
 
 variable "os_disk_size_gb" {
   description = "OS disk size in GB for node pool VMs."
@@ -123,45 +51,7 @@ variable "node_count" {
   type        = number
 }
 
-variable "node_pool_drain_timeout" {
-  description = "Drain timeout in minutes during node upgrade."
-  type        = number
-  default     = 5
-}
-
-variable "node_pool_max_surge" {
-  description = "Maximum surge for node upgrades (e.g., 33%)."
-  type        = string
-}
-
-variable "node_pool_soak_duration" {
-  description = "Node soak duration in minutes before upgrade."
-  type        = number
-  default     = 0
-}
-
-variable "scale_down_delay" {
-  description = "Delay after scale up before scale down."
-  type        = string
-}
-
-variable "scan_interval" {
-  description = "Interval for auto-scaler scan."
-  type        = string
-}
-
 variable "api_server_authorized_ip_ranges" {
   description = "Authorized IP ranges for API server access."
   type        = list(string)
-}
-
-variable "secret_rotation_enabled" {
-  description = "Enable secret rotation for Key Vault provider."
-  type        = bool
-  default     = false
-}
-
-variable "identity_type" {
-  description = "Type of identity for AKS (SystemAssigned, UserAssigned)."
-  type        = string
 }

--- a/modules/network/locals.tf
+++ b/modules/network/locals.tf
@@ -2,8 +2,8 @@ locals {
   subnet_cfg = {
     for name, cfg in var.subnets :
     name => merge(cfg, {
-      name             = name
-      delegations       = cfg.delegations       != null ? cfg.delegations       : []
+      name              = name
+      delegations       = cfg.delegations != null ? cfg.delegations : []
       service_endpoints = cfg.service_endpoints != null ? cfg.service_endpoints : []
     })
   }

--- a/modules/network/locals.tf
+++ b/modules/network/locals.tf
@@ -1,0 +1,6 @@
+locals {
+  subnet_cfg = {
+    for name, cfg in var.subnets :
+    name => merge(cfg, { name = name })
+  }
+}

--- a/modules/network/locals.tf
+++ b/modules/network/locals.tf
@@ -1,6 +1,10 @@
 locals {
   subnet_cfg = {
     for name, cfg in var.subnets :
-    name => merge(cfg, { name = name })
+    name => merge(cfg, {
+      name             = name
+      delegations       = cfg.delegations       != null ? cfg.delegations       : []
+      service_endpoints = cfg.service_endpoints != null ? cfg.service_endpoints : []
+    })
   }
 }

--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -1,0 +1,41 @@
+resource "azurerm_virtual_network" "this" {
+  name                = var.vnet_name
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  address_space       = var.address_space
+}
+
+resource "azurerm_subnet" "this" {
+  for_each             = local.subnet_cfg
+
+  name                 = each.key
+  resource_group_name  = var.resource_group_name
+  virtual_network_name = azurerm_virtual_network.this.name
+  address_prefixes     = each.value.address_prefixes
+
+  service_endpoints    = try(each.value.service_endpoints, null)
+
+  dynamic "delegation" {
+    for_each = each.value.delegations != null ? each.value.delegations : []
+
+    content {
+      name = delegation.value.name
+      service_delegation {
+        name = delegation.value.service
+      }
+    }
+  }
+}
+
+resource "azurerm_subnet_network_security_group_association" "this" {
+  for_each = {
+    for k, v in azurerm_subnet.this :
+    k => {
+      subnet_id = v.id
+      nsg_id    = try(local.subnet_cfg[k].nsg_id, null)
+    } if try(local.subnet_cfg[k].nsg_id, null) != null
+  }
+
+  subnet_id                 = each.value.subnet_id
+  network_security_group_id = each.value.nsg_id
+}

--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -12,7 +12,7 @@ resource "azurerm_subnet" "this" {
   virtual_network_name = azurerm_virtual_network.this.name
   address_prefixes     = each.value.address_prefixes
 
-  service_endpoints    = each.value.service_endpoints
+  service_endpoints = each.value.service_endpoints
 
   dynamic "delegation" {
     for_each = each.value.delegations

--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -7,22 +7,18 @@ resource "azurerm_virtual_network" "this" {
 
 resource "azurerm_subnet" "this" {
   for_each             = local.subnet_cfg
-
-  name                 = each.key
+  name                 = each.value.name
   resource_group_name  = var.resource_group_name
   virtual_network_name = azurerm_virtual_network.this.name
   address_prefixes     = each.value.address_prefixes
 
-  service_endpoints    = try(each.value.service_endpoints, null)
+  service_endpoints    = each.value.service_endpoints
 
   dynamic "delegation" {
-    for_each = each.value.delegations != null ? each.value.delegations : []
-
+    for_each = each.value.delegations
     content {
       name = delegation.value.name
-      service_delegation {
-        name = delegation.value.service
-      }
+      service_delegation { name = delegation.value.service }
     }
   }
 }

--- a/modules/network/outputs.tf
+++ b/modules/network/outputs.tf
@@ -1,0 +1,9 @@
+output "vnet_id" {
+  description = "ID of the created virtual network."
+  value       = azurerm_virtual_network.this.id
+}
+
+output "subnet_ids" {
+  description = "Map of subnet names to their IDs."
+  value       = { for k, s in azurerm_subnet.this : k => s.id }
+}

--- a/modules/network/providers.tf
+++ b/modules/network/providers.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.7.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 4.33.0"
+    }
+  }
+}

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -31,7 +31,7 @@ EOF
     address_prefixes  = list(string)
     nsg_id            = optional(string)
     service_endpoints = optional(list(string))
-    delegations       = optional(list(object({
+    delegations = optional(list(object({
       name    = string
       service = string
     })))

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -1,0 +1,39 @@
+variable "resource_group_name" {
+  type        = string
+  description = "Existing RG where the network will live."
+}
+
+variable "location" {
+  type        = string
+  description = "Azure region (e.g. eastus2)."
+}
+
+variable "vnet_name" {
+  type        = string
+  description = "Name of the virtual network."
+}
+
+variable "address_space" {
+  type        = list(string)
+  description = "Address CIDR blocks for the VNet."
+}
+
+variable "subnets" {
+  description = <<EOF
+Map whose keys are subnet names.  
+Value is an object with:
+  * address_prefixes   — list(string) (required)  
+  * nsg_id             — string (optional)  
+  * service_endpoints  — list(string) (optional)  
+  * delegations        — list(object({ name = string, service = string })) (optional)
+EOF
+  type = map(object({
+    address_prefixes  = list(string)
+    nsg_id            = optional(string)
+    service_endpoints = optional(list(string))
+    delegations       = optional(list(object({
+      name    = string
+      service = string
+    })))
+  }))
+}


### PR DESCRIPTION
This pull request introduces Terraform modules for creating and managing an Azure Kubernetes Service (AKS) cluster and its supporting network infrastructure. The changes include defining resources, variables, outputs, and provider requirements for both the AKS and network modules. Below is a breakdown of the most important changes:

### AKS Module Enhancements
* Added the `azurerm_kubernetes_cluster` resource in `modules/aks/main.tf` to define the AKS cluster with features like workload identity, Istio-based service mesh, and auto-scaling configurations.
* Introduced output variables in `modules/aks/outputs.tf` to expose the cluster name, ID, and kubeconfig details.
* Defined required Terraform and Azurerm provider versions in `modules/aks/providers.tf`.
* Declared input variables in `modules/aks/variables.tf` for configurable parameters such as cluster name, location, Kubernetes version, and node pool settings.

### Network Module Enhancements
* Added resources in `modules/network/main.tf` to create a virtual network, subnets, and associate subnets with network security groups. Dynamic delegation support for subnets is also included.
* Exposed outputs in `modules/network/outputs.tf` for the virtual network ID and a map of subnet IDs.
* Defined required Terraform and Azurerm provider versions in `modules/network/providers.tf`.
* Introduced input variables in `modules/network/variables.tf` to configure the virtual network name, address space, and subnets.

These changes collectively enable the provisioning of a complete AKS environment with its associated network setup in Azure.